### PR TITLE
Fix Black Lion Claim Ticket and Black Lion Statuette parsing

### DIFF
--- a/src/gw2wiki/blackLionStatuette.js
+++ b/src/gw2wiki/blackLionStatuette.js
@@ -2,10 +2,10 @@ import { getSmwQueryResult } from './helpers.js'
 
 // Get the current claim ticket offers
 export default async function blackLionStatuette () {
-  const result = await getSmwQueryResult('[[Has vendor::Black Lion Statuette]][[Has item cost.Has item currency::Black Lion Statuette]]|?Sells item=item|?Has item cost.Has item value=value')
+  const result = await getSmwQueryResult('[[Has vendor::Black Lion Statuette]][[Has item cost.Has item currency::Black Lion Statuette]]|?Sells item=item|?Has item cost=value')
 
   const map = Object.values(result.query.results).map(data => {
-    return [data.printouts['item'][0].fulltext, parseInt(data.printouts['value'][0])]
+    return [data.printouts['item'][0].fulltext, parseInt(data.printouts['value'][0]['Has item value'].item[0])]
   })
 
   return Object.fromEntries(map)

--- a/src/gw2wiki/blackLionStatuette.js
+++ b/src/gw2wiki/blackLionStatuette.js
@@ -1,19 +1,12 @@
-import { getWikiHtml } from './helpers.js'
-import execAll from 'execall'
+import { getSmwQueryResult } from './helpers.js'
 
 // Get the current claim ticket offers
 export default async function blackLionStatuette () {
-  let page = await getWikiHtml('Black_Lion_Statuette')
+  const result = await getSmwQueryResult('[[Has vendor::Black Lion Statuette]][[Has item cost.Has item currency::Black Lion Statuette]]|?Sells item=item|?Has item cost.Has item value=value')
 
-  // Find all items sold for Black Lion Statuette with their costs
-  let regex = /<tr[\s\S]*?<a href="[^"]*" title="([^"]*)">[\s\S]*?class="inline-icon">(\d*)(&nbsp;|&#160;)*<a [^>]* title="Black Lion Statuette"[\s\S]*?<\/tr>/gi
-  let matches = execAll(regex, page).map(x => x.sub)
-
-  let map = {}
-  matches.map(x => {
-    const name = x[0].replace(/&#39;/g, `'`)
-    map[name] = parseInt(x[1], 10)
+  const map = Object.values(result.query.results).map(data => {
+    return [data.printouts['item'][0].fulltext, parseInt(data.printouts['value'][0])]
   })
 
-  return map
+  return Object.fromEntries(map)
 }

--- a/src/gw2wiki/claimTicketOffers.js
+++ b/src/gw2wiki/claimTicketOffers.js
@@ -1,22 +1,12 @@
-import { getWikiHtml } from './helpers.js'
-import execAll from 'execall'
+import { getSmwQueryResult } from './helpers.js'
 
 // Get the current claim ticket offers
 export default async function claimTicketOffers () {
-  let page = await getWikiHtml('Template:Inventory/black_lion_claim_ticket')
+  const result = await getSmwQueryResult('[[Has vendor::Black Lion Claim Ticket]][[Has item cost.Has item currency::Black Lion Claim Ticket]]|?Sells item=item|?Has item cost.Has item value=value')
 
-  // Find all items sold for black lion tickets with their costs
-  let regex = /<tr[\s\S]*?<a href="[^"]*" title="([^"]*)">[\s\S]*?class="inline-icon">(\d*)(&nbsp;|&#160;)*<a [^>]* title="Black Lion Claim Ticket"[\s\S]*?<\/tr>/gi
-  let matches = execAll(regex, page).map(x => x.sub)
-
-  let map = {}
-  matches.map(x => {
-    const name = x[0].replace(/&#39;/g, `'`)
-    map[name] = parseInt(x[1], 10)
+  const map = Object.values(result.query.results).map(data => {
+    return [data.printouts['item'][0].fulltext, parseInt(data.printouts['value'][0])]
   })
 
-  // Remove failures
-  delete map['Black Lion Claim Ticket']
-
-  return map
+  return Object.fromEntries(map)
 }

--- a/src/gw2wiki/helpers.js
+++ b/src/gw2wiki/helpers.js
@@ -47,3 +47,16 @@ export async function getWikiImage (file) {
 
   return imageinfo ? imageinfo[0]['url'] : null
 }
+
+/**
+ * Get SMW query result.
+ *
+ * @param {string} query
+ * @returns {Promise<{ query: { results: Record<string, { printouts: Record<string, (string | { fulltext: string  })[]> }> } }>}
+ */
+export function getSmwQueryResult (query) {
+  const url = `https://wiki.guildwars2.com/api.php?action=ask&query=${encodeURIComponent(query)}&format=json`
+  console.log(url)
+
+  return fetch.single(url, { headers })
+}

--- a/src/gw2wiki/helpers.js
+++ b/src/gw2wiki/helpers.js
@@ -56,7 +56,6 @@ export async function getWikiImage (file) {
  */
 export function getSmwQueryResult (query) {
   const url = `https://wiki.guildwars2.com/api.php?action=ask&query=${encodeURIComponent(query)}&format=json`
-  console.log(url)
 
   return fetch.single(url, { headers })
 }

--- a/tests/gw2wiki/blackLionStatuette.spec.js
+++ b/tests/gw2wiki/blackLionStatuette.spec.js
@@ -13,12 +13,16 @@ describe('gw2wiki > blackLionStatuette', function () {
   })
 
   it('gets the correct claim ticket offers {LIVE}', async () => {
-    let offers = await blackLionStatuette()
-    let offerKeys = Object.keys(offers)
+    const offers = await blackLionStatuette()
+    const offerEntries = Object.entries(offers)
 
-    expect(offerKeys.length).to.be.above(10)
-    expect(typeof offerKeys[0]).to.equal('string')
-    expect(typeof offers[offerKeys[0]]).to.equal('number')
-    expect(offers[offerKeys[0]]).to.be.above(0)
+    expect(offerEntries.length).to.be.above(10)
+
+    Object.entries(offers).forEach(([item, cost]) => {
+      expect(typeof item).to.equal('string')
+      expect(typeof cost).to.equal('number')
+      expect(cost).to.be.not.NaN
+      expect(cost).to.be.above(0)
+    })
   })
 })

--- a/tests/gw2wiki/claimTicketOffers.spec.js
+++ b/tests/gw2wiki/claimTicketOffers.spec.js
@@ -13,12 +13,16 @@ describe('gw2wiki > claimTicketOffers', function () {
   })
 
   it('gets the correct claim ticket offers {LIVE}', async () => {
-    let offers = await claimTicketOffers()
-    let offerKeys = Object.keys(offers)
+    const offers = await claimTicketOffers()
+    const offerEntries = Object.entries(offers)
 
-    expect(offerKeys.length).to.be.above(10)
-    expect(typeof offerKeys[0]).to.equal('string')
-    expect(typeof offers[offerKeys[0]]).to.equal('number')
-    expect(offers[offerKeys[0]]).to.be.above(0)
+    expect(offerEntries.length).to.be.above(10)
+
+    Object.entries(offers).forEach(([item, cost]) => {
+      expect(typeof item).to.equal('string')
+      expect(typeof cost).to.equal('number')
+      expect(cost).to.be.not.NaN
+      expect(cost).to.be.above(0)
+    })
   })
 })


### PR DESCRIPTION
Instead of regex parsing the parsing for these 2 items now uses a SMW api query.